### PR TITLE
add spidertron extended support

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -26,8 +26,8 @@ end
 script.on_nth_tick(60, OnTick)
 
 script.on_event(defines.events.on_built_entity, function(event)
-	for SpiderName in SpiderNames do
-		if event.created_entity.name == SpiderName
+	for _, name in pairs(SpiderNames) do
+		if event.created_entity.name == name
 		then
 			AddSpider(event.created_entity)
 		end
@@ -38,17 +38,10 @@ script.on_event(defines.events.on_entity_destroyed, function (event)
 	global.Spiders[event.registration_number] = nil
 end)
 
-script.on_event(
-	defines.events.on_player_mined_entity,
-	function(event)
-		for key, spider in pairs(global.Spiders) do
-			if spider == event.entity then
-				global.Spiders[key] = nil
-			end
-		end
-	end,
-	{{filter = "name", name = SpiderNames[1]}}
-)
+local mineFilters = {}
+for _, Name in pairs(SpiderNames) do
+	table.insert(mineFilters, {filter = "name", name = Name})
+end
 
 script.on_event(
 	defines.events.on_player_mined_entity,
@@ -59,15 +52,5 @@ script.on_event(
 			end
 		end
 	end,
-	{{filter = "name", name = SpiderNames[2]}}
-	
-script.on_event(
-	defines.events.on_player_mined_entity,
-	function(event)
-		for key, spider in pairs(global.Spiders) do
-			if spider == event.entity then
-				global.Spiders[key] = nil
-			end
-		end
-	end,
-	{{filter = "name", name = SpiderNames[3]}}
+	mineFilters
+)

--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,4 @@
-SpiderName = "spidertron"
+SpiderNames = {"spidertron", "spidertronmk2", "spidertronmk3"}
 
 function AddSpider(spider)
 	local regNum = script.register_on_entity_destroyed(spider)
@@ -6,7 +6,10 @@ function AddSpider(spider)
 end
 
 script.on_init(function()
-	local spiders = game.surfaces.nauvis.find_entities_filtered{name=SpiderName}
+	local spiders = {}
+	for SpiderName in SpiderNames do 
+		spiders.insert(game.surfaces.nauvis.find_entities_filtered{name=SpiderName})
+	end
 	global.Spiders = {}
 	for _, spider in pairs(spiders) do
 		AddSpider(spider)
@@ -23,9 +26,11 @@ end
 script.on_nth_tick(60, OnTick)
 
 script.on_event(defines.events.on_built_entity, function(event)
-	if event.created_entity.name == SpiderName
-	then
-		AddSpider(event.created_entity)
+	for SpiderName in SpiderNames do
+		if event.created_entity.name == SpiderName
+		then
+			AddSpider(event.created_entity)
+		end
 	end
 end)
 
@@ -42,5 +47,27 @@ script.on_event(
 			end
 		end
 	end,
-	{{filter = "name", name = SpiderName}}
+	{{filter = "name", name = SpiderNames[1]}}
 )
+
+script.on_event(
+	defines.events.on_player_mined_entity,
+	function(event)
+		for key, spider in pairs(global.Spiders) do
+			if spider == event.entity then
+				global.Spiders[key] = nil
+			end
+		end
+	end,
+	{{filter = "name", name = SpiderNames[2]}}
+	
+script.on_event(
+	defines.events.on_player_mined_entity,
+	function(event)
+		for key, spider in pairs(global.Spiders) do
+			if spider == event.entity then
+				global.Spiders[key] = nil
+			end
+		end
+	end,
+	{{filter = "name", name = SpiderNames[3]}}

--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
 {
   "name": "SpidertronInventoryImproved",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "title": "Improved Spidertron Inventory",
   "author": "Tomeamis",
   "factorio_version": "1.1",
   "dependencies": ["base >= 1.0"],
-  "description": "For now, just sort the inventory of all spidertrons once every second"
+  "description": "For now, just sort the inventory of all spidertrons once every second. Supports spidertron extended mod."
 }


### PR DESCRIPTION
Updated to sort the inventories of the SpidertronMK2 and SpidertronMK3 created by the spidertron-extended mod.